### PR TITLE
`EMERGENCY_PARSER` support

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2447,7 +2447,7 @@
  * Currently handles M108, M112, M410, M876
  * NOTE: Not yet implemented for all platforms.
  */
-//#define EMERGENCY_PARSER
+#define EMERGENCY_PARSER
 
 /**
  * Realtime Reporting (requires EMERGENCY_PARSER)

--- a/Marlin/src/HAL/HC32F46x/HAL.cpp
+++ b/Marlin/src/HAL/HC32F46x/HAL.cpp
@@ -1,0 +1,18 @@
+#include "HAL.h"
+
+//
+// Emergency Parser
+//
+
+#if ENABLED(EMERGENCY_PARSER)
+void usart_rx_irq_hook(uint8_t ch, uint8_t usart)
+{
+    // only handle receive on USART channel 2 (PRINT/HOST serial)
+    if (usart != 2)
+        return;
+
+    // submit character to emergency parser
+    if (MYSERIAL1.emergency_parser_enabled())
+        emergency_parser.update(MYSERIAL1.emergency_state, ch);
+}
+#endif

--- a/Marlin/src/HAL/HC32F46x/HAL.h
+++ b/Marlin/src/HAL/HC32F46x/HAL.h
@@ -62,6 +62,14 @@
 #endif
 
 //
+// Emergency Parser
+//
+
+#if ENABLED(EMERGENCY_PARSER)
+void usart_rx_irq_hook(uint8_t ch, uint8_t usart);
+#endif
+
+//
 // Misc. Defines
 //
 

--- a/Marlin/src/HAL/HC32F46x/inc/SanityCheck.h
+++ b/Marlin/src/HAL/HC32F46x/inc/SanityCheck.h
@@ -25,10 +25,6 @@
  * Test HC32F46x-specific configuration values for errors at compile-time.
  */
 
-#if ENABLED(EMERGENCY_PARSER)
-#error "EMERGENCY_PARSER is not yet implemented for HC32F46x. Disable EMERGENCY_PARSER to continue."
-#endif
-
 #if ENABLED(FAST_PWM_FAN)
 #error "FAST_PWM_FAN is not yet implemented for this platform."
 #endif
@@ -56,9 +52,7 @@
 #error "NEOPIXEL_LED (Adafruit NeoPixel) is not supported for HC32F46x. Comment out this line to proceed at your own risk!"
 #endif
 
-// Emergency Parser needs at least one serial with HardwareSerial or USBComposite.
-// The USBSerial maple don't allow any hook to implement EMERGENCY_PARSER.
-// And copy all USBSerial code to marlin space to support EMERGENCY_PARSER, when we have another options, don't worth it.
-#if ENABLED(EMERGENCY_PARSER) && !defined(USE_USB_COMPOSITE) && ((SERIAL_PORT == -1 && !defined(SERIAL_PORT_2)) || (SERIAL_PORT_2 == -1 && !defined(SERIAL_PORT)))
-#error "EMERGENCY_PARSER is only supported by HardwareSerial or USBComposite in HC32F46x."
+// Emergency Parser needs at least one serial with HardwareSerial.
+#if ENABLED(EMERGENCY_PARSER) && ((SERIAL_PORT == -1 && !defined(SERIAL_PORT_2)) || (SERIAL_PORT_2 == -1 && !defined(SERIAL_PORT)))
+#error "EMERGENCY_PARSER is only supported by HardwareSerial on HC32F46x."
 #endif


### PR DESCRIPTION
in this PR, support for marlins emergency parser is added to the HC32F46x HAL.

to implement the feature, two hook calls `usart_tx_irq_hook` and `usart_rx_irq_hook` have been added to the h32 core.
