### PR TITLE
add support for `TEMP_SENSOR_SOC`

### DIFF
--- a/Marlin/src/HAL/HC32F46x/HAL.h
+++ b/Marlin/src/HAL/HC32F46x/HAL.h
@@ -21,9 +21,9 @@
  *
  */
 
-/** 
+/**
  * HAL for HC32F46x based boards
- * 
+ *
  * Note: MarlinHAL class is in MarlinHAL.h/cpp
  */
 
@@ -91,7 +91,7 @@ static_assert(false, "SERIAL_PORT_2 must be from 1 to " STRINGIFY(NUM_UARTS) "."
         static_assert(false, "LCD_SERIAL_PORT must be from 1 to " STRINGIFY(NUM_UARTS) ".")
 #endif
 #if HAS_DGUS_LCD
-#define SERIAL_GET_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
+#define LCD_SERIAL_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
 #endif
 #endif
 
@@ -118,7 +118,7 @@ extern "C" void usart_rx_irq_hook(uint8_t ch, uint8_t usart);
 #define analogInputToDigitalPin(p) (p)
 #endif
 
-//TODO: digitalPinHasPWM is not implemented
+// TODO: digitalPinHasPWM is not implemented
 #ifndef digitalPinHasPWM
 #define digitalPinHasPWM(P) (P) //(PIN_MAP[P].timer_device != nullptr)
 #endif
@@ -147,7 +147,7 @@ extern "C" void usart_rx_irq_hook(uint8_t ch, uint8_t usart);
 //
 // ADC
 //
-#define HAL_ADC_VREF 3.3
+#define HAL_ADC_VREF_MV 3300
 #define HAL_ADC_RESOLUTION 10
 
 #define GET_PIN_MAP_PIN(index) index

--- a/Marlin/src/HAL/HC32F46x/MarlinHAL.h
+++ b/Marlin/src/HAL/HC32F46x/MarlinHAL.h
@@ -4,6 +4,27 @@
 
 typedef gpio_pin_t pin_t;
 
+#if TEMP_SENSOR_SOC
+/**
+ * convert ots measurement float to uint16_t for adc_value()
+ *
+ * @note returns float as integer in degrees C * 100, if T > 0
+ */
+#define OTS_FLOAT_TO_ADC_READING(T) ((T) > 0 ? ((uint16_t)((T)*100.0f)) : 0)
+
+/**
+ * convert adc_value() uint16_t to ots measurement float
+ *
+ * @note see OTS_FLOAT_TO_ADC_READING for inverse
+ * 
+ * @note RAW is oversampled by OVERSAMPLENR, so we need to divide first
+ */
+#define TEMP_SOC_SENSOR(RAW) ((float)(((RAW) / OVERSAMPLENR) / 100))
+#endif
+
+/**
+ * HAL class for Marlin on HC32F46x
+ */
 class MarlinHAL
 {
 public:
@@ -73,6 +94,13 @@ private:
      * pin number of the last pin that was used with adc_start()
      */
     static pin_t last_adc_pin;
+
+    #if TEMP_SENSOR_SOC
+    /**
+     * on-chip temperature sensor value
+     */
+    static float soc_temp;
+    #endif
 };
 
 // M997: trigger firmware update from sd card (after upload)

--- a/Marlin/src/HAL/HC32F46x/MarlinHAL.h
+++ b/Marlin/src/HAL/HC32F46x/MarlinHAL.h
@@ -8,9 +8,9 @@ typedef gpio_pin_t pin_t;
 /**
  * convert ots measurement float to uint16_t for adc_value()
  *
- * @note returns float as integer in degrees C * 100, if T > 0
+ * @note returns float as integer in degrees C * 10, if T > 0
  */
-#define OTS_FLOAT_TO_ADC_READING(T) ((T) > 0 ? ((uint16_t)((T)*100.0f)) : 0)
+#define OTS_FLOAT_TO_ADC_READING(T) ((T) > 0 ? ((uint16_t)((T)*10.0f)) : 0)
 
 /**
  * convert adc_value() uint16_t to ots measurement float
@@ -19,7 +19,7 @@ typedef gpio_pin_t pin_t;
  * 
  * @note RAW is oversampled by OVERSAMPLENR, so we need to divide first
  */
-#define TEMP_SOC_SENSOR(RAW) ((float)(((RAW) / OVERSAMPLENR) / 100))
+#define TEMP_SOC_SENSOR(RAW) ((float)(((RAW) / OVERSAMPLENR) / 10))
 #endif
 
 /**

--- a/Marlin/src/HAL/HC32F46x/dogm/u8g_com_stm32duino_swspi.cpp
+++ b/Marlin/src/HAL/HC32F46x/dogm/u8g_com_stm32duino_swspi.cpp
@@ -20,7 +20,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if BOTH(HAS_GRAPHICAL_LCD, FORCE_SOFT_SPI)
+#if ALL(HAS_GRAPHICAL_LCD, FORCE_SOFT_SPI)
 #warning "'u8g_com_stm32duino_swspi' has not been adapted to HC32F46x. Proceed at your own risk"
 
 
@@ -35,7 +35,8 @@ static uint8_t SPI_speed = SPI_SPEED;
 
 static inline uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, const pin_t miso_pin = -1)
 {
-  LOOP_L_N(i, 8)
+  for(int i = 0; i < 8; i++)
+  for(int i = 0; i < 8; i++)
   {
     if (spi_speed == 0)
     {
@@ -49,17 +50,17 @@ static inline uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, c
     else
     {
       const uint8_t state = (b & 0x80) ? HIGH : LOW;
-      LOOP_L_N(j, spi_speed)
+      for(int j = 0; j < spi_speed; j++)
       WRITE(DOGLCD_MOSI, state);
 
-      LOOP_L_N(j, spi_speed + (miso_pin >= 0 ? 0 : 1))
+      for(int j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); j++)
       WRITE(DOGLCD_SCK, HIGH);
 
       b <<= 1;
       if (miso_pin >= 0 && READ(miso_pin))
         b |= 1;
 
-      LOOP_L_N(j, spi_speed)
+      for(int j = 0; j < spi_speed; j++)     
       WRITE(DOGLCD_SCK, LOW);
     }
   }
@@ -68,7 +69,7 @@ static inline uint8_t swSpiTransfer_mode_0(uint8_t b, const uint8_t spi_speed, c
 
 static inline uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, const pin_t miso_pin = -1)
 {
-  LOOP_L_N(i, 8)
+  for(int i = 0; i < 8; i++)
   {
     const uint8_t state = (b & 0x80) ? HIGH : LOW;
     if (spi_speed == 0)
@@ -80,13 +81,13 @@ static inline uint8_t swSpiTransfer_mode_3(uint8_t b, const uint8_t spi_speed, c
     }
     else
     {
-      LOOP_L_N(j, spi_speed + (miso_pin >= 0 ? 0 : 1))
+      for(int j = 0; j < spi_speed + (miso_pin >= 0 ? 0 : 1); j++)
       WRITE(DOGLCD_SCK, LOW);
 
-      LOOP_L_N(j, spi_speed)
+      for(int j = 0; j < spi_speed; j++)
       WRITE(DOGLCD_MOSI, state);
 
-      LOOP_L_N(j, spi_speed)
+      for(int j = 0; j < spi_speed; j++)
       WRITE(DOGLCD_SCK, HIGH);
     }
     b <<= 1;

--- a/Marlin/src/HAL/HC32F46x/inc/Conditionals_post.h
+++ b/Marlin/src/HAL/HC32F46x/inc/Conditionals_post.h
@@ -24,7 +24,7 @@
 // If no real EEPROM, Flash emulation, or SRAM emulation is available fall back to SD emulation
 #if USE_FALLBACK_EEPROM
 #define SDCARD_EEPROM_EMULATION
-#elif EITHER(I2C_EEPROM, SPI_EEPROM)
+#elif ANY(I2C_EEPROM, SPI_EEPROM)
 #define USE_SHARED_EEPROM 1
 #endif
 

--- a/Marlin/src/HAL/HC32F46x/inc/SanityCheck.h
+++ b/Marlin/src/HAL/HC32F46x/inc/SanityCheck.h
@@ -52,3 +52,13 @@
 #if ENABLED(EMERGENCY_PARSER) && ((SERIAL_PORT == -1 && !defined(SERIAL_PORT_2)) || (SERIAL_PORT_2 == -1 && !defined(SERIAL_PORT)))
 #error "EMERGENCY_PARSER is only supported by HardwareSerial on HC32F46x."
 #endif
+
+#if TEMP_SENSOR_SOC
+#if !defined(TEMP_SOC_PIN)
+#error "TEMP_SOC_PIN must be defined to use TEMP_SENSOR_SOC."
+#endif
+
+#if defined(TEMP_SOC_PIN) && IS_GPIO_PIN(TEMP_SOC_PIN)
+#error "TEMP_SOC_PIN must not be a valid GPIO pin to avoid conflicts."
+#endif
+#endif

--- a/Marlin/src/HAL/HC32F46x/pinsDebug.h
+++ b/Marlin/src/HAL/HC32F46x/pinsDebug.h
@@ -110,7 +110,7 @@ static bool GET_ARRAY_IS_DIGITAL(const int16_t array_pin)
  * @brief print pin PWM status
  * @return true if pin is currently a PWM pin, false otherwise
  */
-static bool pwm_status(const pin_t pin)
+bool pwm_status(const pin_t pin)
 {
     // get timer assignment for pin
     timera_config_t *unit;
@@ -131,7 +131,7 @@ static bool pwm_status(const pin_t pin)
     return timera_is_unit_initialized(unit) && timera_is_channel_active(unit, channel);
 }
 
-static void pwm_details(const pin_t pin)
+void pwm_details(const pin_t pin)
 {
     // get timer assignment for pin
     timera_config_t *unit;
@@ -191,7 +191,7 @@ static void pwm_details(const pin_t pin)
     }
 }
 
-static void print_port(pin_t pin)
+void print_port(pin_t pin)
 {
     const char port = 'A' + char(pin >> 4); // pin div 16
     const int16_t gbit = PIN_MAP[pin].bit_pos;

--- a/Marlin/src/HAL/HC32F46x/pinsDebug.h
+++ b/Marlin/src/HAL/HC32F46x/pinsDebug.h
@@ -31,6 +31,9 @@
 #define NUM_DIGITAL_PINS BOARD_NR_GPIO_PINS
 #define NUMBER_PINS_TOTAL BOARD_NR_GPIO_PINS
 #define VALID_PIN(pin) IS_GPIO_PIN(pin)
+
+// Note: pin_array is defined in `Marlin/src/pins/pinsDebug.h`, and since this file is included
+// after it, it is available in this file as well.
 #define GET_ARRAY_PIN(p) pin_t(pin_array[p].pin)
 #define digitalRead_mod(p) extDigitalRead(p)
 #define PRINT_PIN(p)                                  \

--- a/Marlin/src/HAL/HC32F46x/timers.h
+++ b/Marlin/src/HAL/HC32F46x/timers.h
@@ -45,6 +45,11 @@ extern Timer0 step_timer;
 #define HAL_TIMER_RATE 50000000 // 50MHz
 // #define HAL_TIMER_RATE TIMER0_BASE_FREQUENCY
 
+// TODO: CYCLES_PER_MICROSECOND seems to be used by Marlin to calculate the number of cycles per microsecond in the timer ISRs
+//       by default, it uses F_CPU, but since that is not known at compile time for HC32, we overwrite it here
+#undef CYCLES_PER_MICROSECOND
+#define CYCLES_PER_MICROSECOND (HAL_TIMER_RATE / 1000000UL)
+
 // temperature timer
 #define TEMP_TIMER_NUM (&temp_timer)
 #define TEMP_TIMER_PRIORITY DDL_IRQ_PRIORITY_02

--- a/Marlin/src/pins/hc32f46x/env_validate.h
+++ b/Marlin/src/pins/hc32f46x/env_validate.h
@@ -24,3 +24,7 @@
 #ifndef TARGET_HC32F46x
   #error "Oops! Select an HC32F460 board in 'Tools > Board.'"
 #endif
+
+#ifndef TEMP_SOC_PIN
+  #define TEMP_SOC_PIN 0xff // dummy that is not a valid GPIO, HAL checks for this
+#endif

--- a/ini/hc32.ini
+++ b/ini/hc32.ini
@@ -38,6 +38,7 @@ build_flags =
 	-D DISABLE_SERIAL_GLOBALS					# disable global Serial objects, we use our own
 	-D F_CPU=(SYSTEM_CLOCK_FREQUENCIES.pclk1)	# override F_CPU to PCLK1, as marlin freaks out otherwise...
 	-D PLATFORM_M997_SUPPORT					# enable M997 command
+	-D PANIC_USART_BAUDRATE=115200				# set panic serial baudrate to 115200 (should be equal to host serial baudrate)
 												# options to reduce debug mode footprint (-16K; messages are less verbose)
 	-D __DEBUG_SHORT_FILENAMES					# use short filenames in DDL debug output 
 	-D __CORE_DEBUG_SHORT_FILENAMES				# use short filenames in core debug output


### PR DESCRIPTION
adds support for marlins SOC temperature monitoring, configurable using `TEMP_SENSOR_SOC`. Also removes the temperature monitoring hard-coded in the HC32 HAL.

requires https://github.com/shadow578/Marlin-H32/pull/44

---

to enable, set `#define TEMP_SENSOR_SOC 100` in `Configuration.h`.
configure thermal protection using `#define THERMAL_PROTECTION_SOC` and `#define SOC_MAXTEMP 85` in `Configuration_adv.h`. the defaults are ok as-is.


