### PR TITLE
fix: pin HC32 platform package versions

### DIFF
--- a/ini/hc32.ini
+++ b/ini/hc32.ini
@@ -28,6 +28,10 @@
 #
 [HC32F460_base]
 platform         = https://github.com/shadow578/platform-hc32f46x/archive/1.0.0.zip
+platform_packages =
+  framework-arduino-hc32f46x @ https://github.com/shadow578/framework-arduino-hc32f46x/archive/1.0.0.zip
+  framework-hc32f46x-ddl @ https://github.com/shadow578/framework-hc32f46x-ddl/archive/2.2.0.zip
+
 board            = generic_hc32f460
 build_src_filter = ${common.default_src_filter} +<src/HAL/HC32> +<src/HAL/shared/backtrace>
 build_type       = release


### PR DESCRIPTION
requires further testing, especially what happens when other (older) hc32 packages are already installed